### PR TITLE
hotfix: cwd mismatch and create-sst breaking changes

### DIFF
--- a/packages/cli/bin/appsync-butler.mjs
+++ b/packages/cli/bin/appsync-butler.mjs
@@ -4,7 +4,7 @@ import inquirer from 'inquirer';
 import { readFileSync } from 'fs';
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
-import { mkdir, initCdk, initSst, initSstButler, initButler } from '../lib/index.mjs';
+import { mkdir, initCdk, initSst, initButler } from '../lib/index.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -49,15 +49,15 @@ main.command('bootstrap', { isDefault: true })
         switch (toolkit) {
             case 'sst':
                 await initSst(directory, toolkitArgs);
-                await initSstButler();
+                await initButler(directory, true);
                 break;
             case 'cdk':
                 await initCdk(directory, toolkitArgs);
+                await initButler(directory, false);
                 break;
             case 'none':
                 break;
         }
-        await initButler();
     });
 
 main.parse();


### PR DESCRIPTION
* The passed directory value was neglected when creating
  the necessary directories and installing
  @appsync-butler/core and @appsync-butler/sst.
  Fix: initbutler now accepts a `directory` parameter.

* create-sst pushed breaking changes around a week ago,
  see https://github.com/serverless-stack/sst/commit/86290fe7eef30ce152e9a96870a86417a0a2d515
  The template parameter is now an option instead of an argument.
  Fix: initSst no longer passes an empty ('') argument to bypass the SST
  template argument.

* The current working directory will be printed when executing CLI commands.